### PR TITLE
Changed checkout_index_index layout from `1column` on `checkout`

### DIFF
--- a/view/frontend/layout/checkout_index_index.xml
+++ b/view/frontend/layout/checkout_index_index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="checkout" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceBlock name="checkout.root">
             <arguments>


### PR DESCRIPTION
Zmiana layoutu na `checkout` z `1column` - domyślne zachowanie Magento 2. Aktualnie jest ustawiony layout `1column` co powoduje wyświetlanie wyszukiwarki, minicart'a oraz górnej nawigacji na widoku checkout co nie jest domyślnym zachowaniem Magento 2.